### PR TITLE
fix: Update the value of locale

### DIFF
--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -9,17 +9,32 @@ import zhCN from 'vant/es/locale/lang/zh-CN'
 import messages from '@intlify/unplugin-vue-i18n/messages'
 import { Locale, type PickerColumn } from 'vant'
 
-export const i18n = createI18n({
-  locale: localStorage.getItem('language') || navigator.language,
-  fallbackLocale: 'zhCN',
-  messages,
-})
+/** 默认语言包名称 */
+const FALLBACK_LOCALE = 'zh-CN'
 
 /** 多语言 picker columns */
 export const languageColumns: PickerColumn = [
   { text: '简体中文', value: 'zh-CN' },
   { text: 'English', value: 'en-US' },
 ]
+
+/** 获取当前语言对应的语言包名称 */
+function getI18nLocale() {
+  const locale = localStorage.getItem('language') || navigator.language
+  for (const l of languageColumns) {
+    const value = l.value as string
+    if (value === locale)
+      return locale // 存在当前语言的语言包
+    else if (value.indexOf(locale) === 0)
+      return value // 存在当前语言的任意地区的语言包
+  }
+  return FALLBACK_LOCALE // 使用默认语言包
+}
+
+export const i18n = createI18n({
+  locale: getI18nLocale(),
+  messages,
+})
 
 /** 当前语言 */
 export const locale = computed({


### PR DESCRIPTION
更新 `createI18n` 中 `locale` 的取值逻辑:
- 增加默认的语言包名称 `FALLBACK_LOCALE`
- 支持只有语言的格式, 例如当前语言为 `zh` 时, 匹配 `zh-CN`