### PR TITLE
fix: pin vue-router to `5.0.2` to fix Node 20 build failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "vconsole": "^3.15.1",
     "vue": "^3.5.29",
     "vue-i18n": "^11.2.8",
-    "vue-router": "^5.0.3"
+    "vue-router": "5.0.2"
   },
   "devDependencies": {
     "@antfu/eslint-config": "7.4.3",
@@ -94,7 +94,8 @@
     ]
   },
   "resolutions": {
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vue-router": "5.0.2"
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm lint-staged",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   vite: ^7.3.1
+  vue-router: 5.0.2
 
 importers:
 
@@ -57,8 +58,8 @@ importers:
         specifier: ^11.2.8
         version: 11.2.8(vue@3.5.29(typescript@5.9.3))
       vue-router:
-        specifier: ^5.0.3
-        version: 5.0.3(@vue/compiler-sfc@3.5.29)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.29(typescript@5.9.3)))(vue@3.5.29(typescript@5.9.3))
+        specifier: 5.0.2
+        version: 5.0.2(@vue/compiler-sfc@3.5.29)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.29(typescript@5.9.3)))(vue@3.5.29(typescript@5.9.3))
     devDependencies:
       '@antfu/eslint-config':
         specifier: 7.4.3
@@ -2949,7 +2950,6 @@ packages:
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   global-directory@4.0.1:
@@ -4623,8 +4623,8 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
-  vue-router@5.0.3:
-    resolution: {integrity: sha512-nG1c7aAFac7NYj8Hluo68WyWfc41xkEjaR0ViLHCa3oDvTQ/nIuLJlXJX1NUPw/DXzx/8+OKMng045HHQKQKWw==}
+  vue-router@5.0.2:
+    resolution: {integrity: sha512-YFhwaE5c5JcJpNB1arpkl4/GnO32wiUWRB+OEj1T0DlDxEZoOfbltl2xEwktNU/9o1sGcGburIXSpbLpPFe/6w==}
     peerDependencies:
       '@pinia/colada': '>=0.21.2'
       '@vue/compiler-sfc': ^3.5.17
@@ -9816,7 +9816,7 @@ snapshots:
       '@vue/devtools-api': 6.6.4
       vue: 3.5.29(typescript@5.9.3)
 
-  vue-router@5.0.3(@vue/compiler-sfc@3.5.29)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.29(typescript@5.9.3)))(vue@3.5.29(typescript@5.9.3)):
+  vue-router@5.0.2(@vue/compiler-sfc@3.5.29)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.29(typescript@5.9.3)))(vue@3.5.29(typescript@5.9.3)):
     dependencies:
       '@babel/generator': 7.29.1
       '@vue-macros/common': 3.1.2(vue@3.5.29(typescript@5.9.3))


### PR DESCRIPTION
vue-router 5.0.3 introduces a bug in collectDuplicatedRouteNodes (seen.values().filter is not a function) that breaks the build on Node 20. The error surfaces as:
[vite-plugin-pwa:build] Could not load vue-router/auto-routes (imported by src/router/index.ts): seen.values(...).filter is not a function

It also indirectly causes vite-plugin-sitemap ENOENT for robots.txt when the build fails early before dist is created.

Pin to 5.0.2 until vue-router fixes the issue.