### PR TITLE
feat(i18n): add Korean (ko-KR) translation

### DIFF
--- a/src/locales/ko-KR.json
+++ b/src/locales/ko-KR.json
@@ -1,0 +1,133 @@
+{
+  "app": {
+    "name": "Vue3 Vant Mobile",
+    "description": "Vue 3 생태계 기반의 모바일 웹 앱 템플릿"
+  },
+
+  "navbar": {
+    "Home": "홈",
+    "Profile": "프로필",
+    "Mock": "🗂️ Mock",
+    "Charts": "📊 차트",
+    "UnoCSS": "⚡ UnoCSS",
+    "Counter": "🍍 상태 유지",
+    "KeepAlive": "♻️ 페이지 캐시",
+    "ScrollCache": "📍 스크롤 캐시",
+    "Login": "🧑‍💻 로그인",
+    "Register": "🧑‍💻 회원가입",
+    "ForgotPassword": "❓ 비밀번호 찾기",
+    "Settings": "⚙️ 설정",
+    "404": "⚠️ 404 페이지",
+    "Undefined": "🤷 제목 없음"
+  },
+
+  "tabbar": {
+    "home": "홈",
+    "profile": "프로필"
+  },
+
+  "home": {
+    "darkMode": "🌗 다크 모드",
+    "language": "📚 언어",
+    "settings": "설정",
+    "examples": "예제"
+  },
+
+  "profile": {
+    "login": "로그인",
+    "settings": "설정",
+    "docs": "문서"
+  },
+
+  "mock": {
+    "fromAsyncData": "비동기 요청으로 받은 데이터",
+    "noData": "데이터 없음",
+    "pull": "요청",
+    "reset": "초기화"
+  },
+
+  "charts": {
+    "January": "1월",
+    "February": "2월",
+    "March": "3월",
+    "April": "4월",
+    "May": "5월",
+    "June": "6월"
+  },
+
+  "counter": {
+    "description": "이 카운터의 상태는 Pinia를 통해 유지됩니다. 페이지를 새로고침하여 확인해 보세요."
+  },
+
+  "unocss": {
+    "title": "안녕하세요, Unocss!",
+    "description": "Unocss 사용 예제입니다.",
+    "button": "버튼"
+  },
+
+  "keepAlive": {
+    "label": "현재 컴포넌트는 캐시됩니다"
+  },
+
+  "scrollCache": {
+    "sectionTitle": "섹션 제목",
+    "sectionText": "섹션 내용 섹션 내용 섹션 내용 섹션 내용 섹션 내용 섹션 내용",
+    "finished": "마지막까지 도달했습니다 ~",
+    "loading": "로딩 중..."
+  },
+
+  "login": {
+    "login": "로그인",
+    "logout": "로그아웃",
+    "email": "이메일",
+    "password": "비밀번호",
+    "pleaseEnterEmail": "이메일을 입력해 주세요",
+    "pleaseEnterPassword": "비밀번호를 입력해 주세요",
+    "signUp": "회원가입하기",
+    "forgotPassword": "비밀번호를 잊으셨나요?"
+  },
+
+  "forgotPassword": {
+    "email": "이메일",
+    "code": "인증 코드",
+    "password": "비밀번호",
+    "confirmPassword": "비밀번호 재입력",
+    "pleaseEnterEmail": "이메일을 입력해 주세요",
+    "pleaseEnterCode": "인증 코드를 입력해 주세요",
+    "pleaseEnterPassword": "비밀번호를 입력해 주세요",
+    "pleaseEnterConfirmPassword": "비밀번호를 다시 입력해 주세요",
+    "passwordsDoNotMatch": "비밀번호가 일치하지 않습니다",
+    "confirm": "확인",
+    "backToLogin": "로그인으로 돌아가기",
+    "getCode": "인증 코드 받기",
+    "gettingCode": "전송 중",
+    "sendCodeSuccess": "전송되었습니다. 인증 코드는",
+    "passwordResetSuccess": "비밀번호가 재설정되었습니다"
+  },
+
+  "register": {
+    "email": "이메일",
+    "code": "인증 코드",
+    "nickname": "닉네임",
+    "password": "비밀번호",
+    "confirmPassword": "비밀번호 재입력",
+    "pleaseEnterEmail": "이메일을 입력해 주세요",
+    "pleaseEnterCode": "인증 코드를 입력해 주세요",
+    "pleaseEnterNickname": "닉네임을 입력해 주세요",
+    "pleaseEnterPassword": "비밀번호를 입력해 주세요",
+    "pleaseEnterConfirmPassword": "비밀번호를 다시 입력해 주세요",
+    "passwordsDoNotMatch": "비밀번호가 일치하지 않습니다",
+    "confirm": "확인",
+    "backToLogin": "로그인으로 돌아가기",
+    "getCode": "인증 코드 받기",
+    "gettingCode": "전송 중",
+    "sendCodeSuccess": "전송되었습니다. 인증 코드는",
+    "registerSuccess": "회원가입이 완료되었습니다"
+  },
+
+  "settings": {
+    "logout": "로그아웃",
+    "currentVersion": "현재 버전",
+    "confirmTitle": "종료하시겠습니까?"
+  }
+}

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -1,6 +1,7 @@
 import { createI18n } from 'vue-i18n'
 import enUS from 'vant/es/locale/lang/en-US'
 import zhCN from 'vant/es/locale/lang/zh-CN'
+import koKR from 'vant/es/locale/lang/ko-KR'
 import { Locale } from 'vant'
 import type { PickerColumn } from 'vant'
 
@@ -9,11 +10,13 @@ const FALLBACK_LOCALE = 'zh-CN'
 const vantLocales = {
   'zh-CN': zhCN,
   'en-US': enUS,
+  'ko-KR': koKR,
 }
 
 export const languageColumns: PickerColumn = [
   { text: '简体中文', value: 'zh-CN' },
   { text: 'English', value: 'en-US' },
+  { text: '한국어', value: 'ko-KR' },
 ]
 
 export const i18n = setupI18n()


### PR DESCRIPTION
## Motivation

This adds Korean (`ko`) translation support — to help Korean-speaking users use this
open-source project more comfortably in their own language.
(한국 사람들의 오픈소스 이용에 도움이 되게 하기 위해서 한글화 작업을 하였습니다.)

## Changes

- Add `src/locales/ko-KR.json` with a full Korean translation, matching all 87 keys present in `en-US.json` and `zh-CN.json` (app, navbar, tabbar, home, profile, mock, charts, counter, unocss, keepAlive, scrollCache, login, forgotPassword, register, settings).
- Register `ko-KR` in `src/utils/i18n.ts`: added it to `languageColumns` (so it shows up in the in-app language picker as "한국어") and wired up Vant's built-in `ko-KR` component locale (`vant/es/locale/lang/ko-KR`) so Vant UI components (pickers, dialogs, etc.) are also localized when Korean is selected.

## Testing

- `pnpm lint` — passes.
- `pnpm typecheck` (`vue-tsc --noEmit`) — passes.
- `pnpm build:pro` — production build succeeds and includes the new `ko-KR` locale chunk alongside the existing `en-US`/`zh-CN` chunks.
- Verified key parity programmatically: `ko-KR.json` has the same 87 flattened keys as `en-US.json` and `zh-CN.json` (no missing/extra keys).
- Confirmed there are no interpolation placeholders in any `$t()` call sites in the codebase, so no placeholder-preservation risk in this translation.